### PR TITLE
Add Week 1 deep learning foundations notebook content

### DIFF
--- a/notebooks/W01_intro_dl.ipynb
+++ b/notebooks/W01_intro_dl.ipynb
@@ -2,41 +2,311 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "0",
+   "id": "6865594c",
    "metadata": {},
    "source": [
-    "# W01 · Intro to DL & TensorFlow/Keras\n",
+    "# W01 · Deep Learning Foundations\n",
     "\n",
-    "This notebook is scaffolded for the Deep Learning Course 2025. Replace the placeholder content with the week's material.\n"
+    "This week introduces the basic building blocks of deep learning with tensors, gradients, and a tiny neural network.\n",
+    "\n",
+    "**Ahmed Métwalli** – LinkedIn | ResearchGate  \\\n",
+    "Assistant Lecturer (MSc) at AASTMT focused on AI and Data Science. With over 15 publications and multidisciplinary projects across AI applications, a Ph.D. is being pursued on machine-learning-based wireless channel identification."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "1",
+   "id": "5af97217",
    "metadata": {},
    "source": [
-    "## Getting Started\n",
-    "1. Duplicate `templates/notebook_template.py` using `scripts/new_week.py` for fresh content.\n",
-    "2. Update the Objectives section, add experiments, and track logs under `runs/`.\n",
-    "3. Commit with clean outputs—`pre-commit` will strip execution results automatically.\n"
+    "## Objectives\n",
+    "\n",
+    "- Understand tensors and automatic differentiation at a high level\n",
+    "- Learn mean squared error (MSE)\n",
+    "- Train a tiny dense model on Fashion-MNIST\n",
+    "- Log training to TensorBoard"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2",
+   "id": "9ce34e36",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Placeholder cell. Start building the lesson by importing TensorFlow and course utilities.\n",
-    "print(\"Welcome to W01 · Intro to DL & TensorFlow/Keras! Replace this cell with your code.\")\n"
+    "# Basic setup and reproducibility\n",
+    "import tensorflow as tf, keras, random, numpy as np\n",
+    "print(\"TF:\", tf.__version__, \"| Keras:\", keras.__version__)\n",
+    "print(\"Devices:\", tf.config.list_physical_devices())\n",
+    "\n",
+    "SHOW_SOLUTIONS = False\n",
+    "\n",
+    "SEED = 2025\n",
+    "random.seed(SEED); np.random.seed(SEED); tf.random.set_seed(SEED)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b287482e",
+   "metadata": {},
+   "source": [
+    "## Very Short Concepts\n",
+    "\n",
+    "A tensor is a generalization of scalars, vectors, and matrices.\n",
+    "\n",
+    "Automatic differentiation computes gradients of a loss with respect to model weights."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4b06d97e",
+   "metadata": {},
+   "source": [
+    "## Math: MSE and gradients\n",
+    "\n",
+    "The mean squared error compares predictions with targets.\n",
+    "\n",
+    "$$\\text{MSE}(y, \\hat{y}) = \\frac{1}{N} \\sum_{i=1}^{N} (y_i - \\hat{y}_i)^2$$\n",
+    "\n",
+    "For $\\hat{y}_i = w x_i + b$ the gradients become\n",
+    "\n",
+    "$$\\frac{\\partial L}{\\partial w} = -\\frac{2}{N} \\sum_{i} x_i\\,(y_i - (w x_i + b))$$\n",
+    "\n",
+    "$$\\frac{\\partial L}{\\partial b} = -\\frac{2}{N} \\sum_{i} (y_i - (w x_i + b))$$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7506d56",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Worked Example A: Closed-form line fit with NumPy\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "# Generate simple data with noise around a line\n",
+    "x = np.linspace(0.0, 5.0, 50)\n",
+    "noise = 0.5 * np.random.randn(50)\n",
+    "y = 2.5 * x + 1.0 + noise\n",
+    "\n",
+    "# Estimate slope and intercept using covariance/variance intuition\n",
+    "x_mean = x.mean()\n",
+    "y_mean = y.mean()\n",
+    "cov_xy = np.mean((x - x_mean) * (y - y_mean))\n",
+    "var_x = np.mean((x - x_mean) ** 2)\n",
+    "slope = cov_xy / var_x\n",
+    "intercept = y_mean - slope * x_mean\n",
+    "print(f\"Estimated slope: {slope:.3f}, intercept: {intercept:.3f}\")\n",
+    "\n",
+    "# Predictions from the fitted line\n",
+    "y_hat = slope * x + intercept\n",
+    "\n",
+    "plt.figure(figsize=(6, 4))\n",
+    "plt.scatter(x, y, label=\"data\")\n",
+    "plt.plot(x, y_hat, color=\"crimson\", label=\"fitted line\")\n",
+    "plt.title(\"Closed-form line fit\")\n",
+    "plt.xlabel(\"x\")\n",
+    "plt.ylabel(\"y\")\n",
+    "plt.legend()\n",
+    "plt.grid(alpha=0.3)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e8f69e0a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Worked Example B: GradientTape mini-demo\n",
+    "import matplotlib.pyplot as plt\n",
+    "import tensorflow as tf, numpy as np\n",
+    "\n",
+    "n = 256\n",
+    "x = tf.linspace(-2.0, 2.0, n)[:, None]\n",
+    "true_w, true_b = 3.0, -0.7\n",
+    "y = true_w * x + true_b + 0.3 * tf.random.normal(shape=x.shape, seed=SEED)\n",
+    "\n",
+    "w = tf.Variable(tf.random.normal([1,1], stddev=0.1, seed=SEED))\n",
+    "b = tf.Variable(tf.zeros([1]))\n",
+    "opt = tf.keras.optimizers.SGD(learning_rate=0.1)\n",
+    "\n",
+    "losses = []\n",
+    "for step in range(200):\n",
+    "    with tf.GradientTape() as tape:\n",
+    "        y_hat = x @ w + b\n",
+    "        loss = tf.reduce_mean((y - y_hat) ** 2)\n",
+    "    grads = tape.gradient(loss, [w, b])\n",
+    "    opt.apply_gradients(zip(grads, [w, b]))\n",
+    "    losses.append(float(loss))\n",
+    "\n",
+    "print(\"Estimated w,b:\", float(w.numpy().squeeze()), float(b.numpy().squeeze()))\n",
+    "\n",
+    "plt.figure(figsize=(6, 4))\n",
+    "plt.plot(losses)\n",
+    "plt.title(\"SGD with GradientTape\")\n",
+    "plt.xlabel(\"Step\")\n",
+    "plt.ylabel(\"MSE loss\")\n",
+    "plt.grid(alpha=0.3)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "76a4c1df",
+   "metadata": {},
+   "source": [
+    "## Lab plan\n",
+    "\n",
+    "An MLP will be trained on Fashion-MNIST. Images will be flattened to 784 features. Early stopping and TensorBoard will be used."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "68508c01",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Data loading with helper utilities\n",
+    "import tensorflow as tf\n",
+    "from dl_utils import load_tfds_dataset, prepare_for_training, build_callbacks, compile_and_fit, plot_history, visualize_model\n",
+    "from keras import layers, models\n",
+    "\n",
+    "# Data\n",
+    "(train_raw, info) = load_tfds_dataset(\"fashion_mnist\", split=\"train\", with_info=True)\n",
+    "test_raw = load_tfds_dataset(\"fashion_mnist\", split=\"test\")\n",
+    "num_classes = info.features[\"label\"].num_classes\n",
+    "\n",
+    "\n",
+    "def to_float_and_flatten(x, y):\n",
+    "    x = tf.image.convert_image_dtype(x, tf.float32)  # [0,1]\n",
+    "    x = tf.reshape(x, (-1,))                         # 28*28\n",
+    "    return x, y\n",
+    "\n",
+    "train_ds = prepare_for_training(train_raw.map(to_float_and_flatten), batch_size=64)\n",
+    "test_ds  = prepare_for_training(test_raw.map(to_float_and_flatten),  batch_size=64, shuffle_buffer=None)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f467bb95",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Model definition, training, and visualization\n",
+    "model = models.Sequential([\n",
+    "    layers.Input((28*28,)),\n",
+    "    layers.Dense(128, activation=\"relu\"),\n",
+    "    layers.Dropout(0.2),\n",
+    "    layers.Dense(num_classes, activation=\"softmax\"),\n",
+    "])\n",
+    "\n",
+    "visualize_model(model)\n",
+    "\n",
+    "callbacks, logdir = build_callbacks(patience=3)\n",
+    "history = compile_and_fit(\n",
+    "    model, train_ds,\n",
+    "    optimizer=keras.optimizers.Adam(1e-3),\n",
+    "    loss=\"sparse_categorical_crossentropy\",\n",
+    "    metrics=[\"accuracy\"],\n",
+    "    epochs=5,\n",
+    "    validation_ds=test_ds,\n",
+    "    callbacks=callbacks\n",
+    ")\n",
+    "\n",
+    "plot_history(history)\n",
+    "print(\"To inspect logs locally: tensorboard --logdir runs\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ab6f4125",
+   "metadata": {},
+   "source": [
+    "## Concept checks\n",
+    "\n",
+    "**Question 1.** What does \"flattening\" do here?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bd81eb6d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if SHOW_SOLUTIONS:\n",
+    "    print(\"It reshapes each 28x28 image into a vector of 784 numbers.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d1cc5b3b",
+   "metadata": {},
+   "source": [
+    "**Question 2.** Why does early stopping help?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "615c584a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if SHOW_SOLUTIONS:\n",
+    "    print(\"It stops training when validation loss stops improving, avoiding wasted epochs and overfitting.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c28f68d7",
+   "metadata": {},
+   "source": [
+    "**Question 3.** What is the difference between training and validation accuracy?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4a773e74",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if SHOW_SOLUTIONS:\n",
+    "    print(\"Training accuracy comes from the batches the model learns on, while validation accuracy uses held-out data.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2c18406b",
+   "metadata": {},
+   "source": [
+    "## Homework\n",
+    "\n",
+    "- **Part A (Derivation):** Re-derive the gradient of MSE for $w$ and $b$ in one paragraph.\n",
+    "- **Part B (Code):** Change the hidden size (e.g., 64 or 256) and report the effect on accuracy after 5 epochs.\n",
+    "- **Part C (Analysis):** In 4–6 lines, describe any sign of overfitting or underfitting from the curves."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a61ca3ee",
+   "metadata": {},
+   "source": [
+    "## Further reading\n",
+    "\n",
+    "- TensorFlow: Autodiff basics\n",
+    "- Keras: Image classification guide\n",
+    "- TensorBoard: Scalars and graphs"
    ]
   }
  ],
  "metadata": {
-  "jupytext": {
-   "formats": "ipynb,py:percent"
-  },
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -44,7 +314,7 @@
   },
   "language_info": {
    "name": "python",
-   "version": "3.11"
+   "version": "3.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Summary
- replace the Week 1 notebook with friendly explanations, objectives, and math for MSE and gradients
- add NumPy and GradientTape examples that connect closed-form fitting with autodiff
- build a Fashion-MNIST lab pipeline with TensorBoard logging hints and concept checks

## Testing
- not run (not required for notebook authoring)

------
https://chatgpt.com/codex/tasks/task_e_68c98b09e36c83269050e652dd08d6a8