### PR TITLE
Enrich Week 1 intro notebook and add lab guide

### DIFF
--- a/notebooks/W01_intro_dl.ipynb
+++ b/notebooks/W01_intro_dl.ipynb
@@ -50,9 +50,11 @@
    "source": [
     "## Very Short Concepts\n",
     "\n",
-    "A tensor is a generalization of scalars, vectors, and matrices.\n",
+    "Tensors package numeric data into structured collections—scalars, vectors, matrices, and higher-order arrays—that deep-learning models can manipulate efficiently, as introduced in Chapters 1-2 of Goodfellow, Bengio, and Courville (2016).\n",
     "\n",
-    "Automatic differentiation computes gradients of a loss with respect to model weights."
+    "Automatic differentiation lets us trace how changes in each tensor ripple through a computation graph so we can update model weights with gradient-based optimization; Géron (2022) walks through this workflow using TensorFlow's GradientTape API.\n",
+    "\n",
+    "Mean squared error (MSE) measures the average squared gap between predictions and targets, grounding our training objective in a smooth loss landscape whose gradients align with the linear-regression derivation you just reviewed (Goodfellow et al., 2016; Géron, 2022)."
    ]
   },
   {
@@ -71,6 +73,16 @@
     "$$\\frac{\\partial L}{\\partial w} = -\\frac{2}{N} \\sum_{i} x_i\\,(y_i - (w x_i + b))$$\n",
     "\n",
     "$$\\frac{\\partial L}{\\partial b} = -\\frac{2}{N} \\sum_{i} (y_i - (w x_i + b))$$"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bdf0a523",
+   "metadata": {},
+   "source": [
+    "### From algebra to NumPy code\n",
+    "\n",
+    "The closed-form line fit below translates the gradient formulas from the previous math cell into vectorized NumPy operations so you can see the symbols come alive in code. Following Géron (2022, Ch. 4), pay attention to how broadcasting and matrix products mirror the analytical solution for linear regression."
    ]
   },
   {
@@ -110,6 +122,16 @@
     "plt.legend()\n",
     "plt.grid(alpha=0.3)\n",
     "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "be32fb0b",
+   "metadata": {},
+   "source": [
+    "### Stepping into automatic differentiation\n",
+    "\n",
+    "To connect the NumPy solution with modern deep-learning practice, the next demo rebuilds the same regression task using `tf.GradientTape`. This mirrors the computational-graph perspective emphasized by Goodfellow et al. (2016) and shows how TensorFlow exposes gradients automatically once the forward pass is defined."
    ]
   },
   {
@@ -175,17 +197,21 @@
     "from keras import layers, models\n",
     "\n",
     "# Data\n",
+    "# Load Fashion-MNIST from TFDS so the lab can focus on modeling instead of boilerplate data wrangling.\n",
     "(train_raw, info) = load_tfds_dataset(\"fashion_mnist\", split=\"train\", with_info=True)\n",
     "test_raw = load_tfds_dataset(\"fashion_mnist\", split=\"test\")\n",
     "num_classes = info.features[\"label\"].num_classes\n",
     "\n",
     "\n",
+    "# Convert images to normalized flat vectors that match the dense network input expectations.\n",
     "def to_float_and_flatten(x, y):\n",
     "    x = tf.image.convert_image_dtype(x, tf.float32)  # [0,1]\n",
     "    x = tf.reshape(x, (-1,))                         # 28*28\n",
     "    return x, y\n",
     "\n",
+    "# Batch and shuffle the training stream to approximate SGD with manageable memory footprints.\n",
     "train_ds = prepare_for_training(train_raw.map(to_float_and_flatten), batch_size=64)\n",
+    "# Batch the evaluation stream without shuffling to keep epoch-level metrics stable.\n",
     "test_ds  = prepare_for_training(test_raw.map(to_float_and_flatten),  batch_size=64, shuffle_buffer=None)"
    ]
   },
@@ -197,6 +223,7 @@
    "outputs": [],
    "source": [
     "# Model definition, training, and visualization\n",
+    "# Stack a minimal dense network so we can isolate how architecture choices affect Fashion-MNIST accuracy.\n",
     "model = models.Sequential([\n",
     "    layers.Input((28*28,)),\n",
     "    layers.Dense(128, activation=\"relu\"),\n",
@@ -204,9 +231,12 @@
     "    layers.Dense(num_classes, activation=\"softmax\"),\n",
     "])\n",
     "\n",
+    "# Render the layer stack to reinforce the correspondence between code and the conceptual diagram.\n",
     "visualize_model(model)\n",
     "\n",
+    "# Configure early stopping and TensorBoard callbacks to monitor learning dynamics in real time.\n",
     "callbacks, logdir = build_callbacks(patience=3)\n",
+    "# Train the model while logging optimizer, loss, and metric history for later inspection.\n",
     "history = compile_and_fit(\n",
     "    model, train_ds,\n",
     "    optimizer=keras.optimizers.Adam(1e-3),\n",
@@ -217,7 +247,9 @@
     "    callbacks=callbacks\n",
     ")\n",
     "\n",
+    "# Summarize the TensorBoard logs inline so you can reason about training curves without leaving the notebook.\n",
     "plot_history(history)\n",
+    "# Remind students where to find the saved run directory for deeper TensorBoard analysis.\n",
     "print(\"To inspect logs locally: tensorboard --logdir runs\")"
    ]
   },
@@ -288,8 +320,9 @@
     "## Homework\n",
     "\n",
     "- **Part A (Derivation):** Re-derive the gradient of MSE for $w$ and $b$ in one paragraph.\n",
-    "- **Part B (Code):** Change the hidden size (e.g., 64 or 256) and report the effect on accuracy after 5 epochs.\n",
-    "- **Part C (Analysis):** In 4–6 lines, describe any sign of overfitting or underfitting from the curves."
+    "- **Part B (Code):** Change the hidden size (e.g., 64 or 256) and report the effect on accuracy using the training history plot.\n",
+    "- **Part C (Optimizer Study):** Compare Adam with SGD by rerunning `compile_and_fit` and summarize how the TensorBoard scalar curves differ after five epochs.\n",
+    "- **Part D (Reflection):** Connect one observation from the GradientTape demo or training logs to the gradient principles discussed above, citing the relevant section in Goodfellow et al. (2016) or Géron (2022)."
    ]
   },
   {
@@ -299,9 +332,8 @@
    "source": [
     "## Further reading\n",
     "\n",
-    "- TensorFlow: Autodiff basics\n",
-    "- Keras: Image classification guide\n",
-    "- TensorBoard: Scalars and graphs"
+    "- Ian Goodfellow, Yoshua Bengio, and Aaron Courville. *Deep Learning*. MIT Press, 2016.\n",
+    "- Aurélien Géron. *Hands-On Machine Learning with Scikit-Learn, Keras, and TensorFlow*. O'Reilly Media, 3rd ed., 2022."
    ]
   }
  ],

--- a/notebooks/W01_lab_guide.tex
+++ b/notebooks/W01_lab_guide.tex
@@ -1,0 +1,53 @@
+\documentclass[11pt]{article}
+\usepackage[margin=1in]{geometry}
+\usepackage{hyperref}
+\usepackage{enumitem}
+\title{Lab 1 Guide: Deep Learning Foundations}
+\author{Course Staff}
+\date{\today}
+\begin{document}
+\maketitle
+
+\section*{Objectives}
+\begin{itemize}[leftmargin=*]
+    \item Internalize how tensors, automatic differentiation, and mean squared error interlock to drive gradient-based learning~\cite{goodfellow2016deep,geron2022hands}.
+    \item Translate analytic gradient derivations into NumPy and TensorFlow implementations that mirror the notebook demos.
+    \item Practice reading optimizer diagnostics in TensorBoard to inform simple model design decisions.
+\end{itemize}
+
+\section*{Key Ideas}
+\begin{itemize}[leftmargin=*]
+    \item Tensors generalize scalars, vectors, and matrices so neural networks can manipulate structured data efficiently~\cite{goodfellow2016deep}.
+    \item Automatic differentiation exposes gradients of composite computations without hand-derived calculus at every step~\cite{geron2022hands}.
+    \item Mean squared error provides a smooth objective whose gradients connect the linear model warm-up to multilayer perceptrons.
+\end{itemize}
+
+\section*{Workflow}
+\begin{enumerate}[leftmargin=*]
+    \item Review the math recap linking MSE gradients to linear regression, then run the NumPy line-fit cell to see the closed-form solution in action.
+    \item Step through the GradientTape mini-demo to observe how TensorFlow records operations and surfaces parameter updates automatically.
+    \item Load Fashion-MNIST with the helper utilities, documenting each preprocessing stage (normalization, flattening, batching) as in the notebook comments.
+    \item Train the baseline dense network, monitor early stopping and TensorBoard callbacks, and interpret the plotted history against your expectations from the math section.
+\end{enumerate}
+
+\section*{Assignments and Exit Ticket}
+\begin{itemize}[leftmargin=*]
+    \item Derive the gradients for $w$ and $b$ under MSE and compare with the notebook's analytical expressions.
+    \item Run the hidden-size and optimizer comparisons, noting how the accuracy curves shift and how TensorBoard visualizes the differences.
+    \item Exit Ticket: Submit a brief reflection connecting one GradientTape observation to the gradient narratives in Goodfellow et~al.~(2016) or Géron (2022).
+\end{itemize}
+
+\bibliographystyle{plain}
+\begin{thebibliography}{9}
+\bibitem{goodfellow2016deep}
+Ian Goodfellow, Yoshua Bengio, and Aaron Courville.
+\newblock \emph{Deep Learning}.
+\newblock MIT Press, 2016.
+
+\bibitem{geron2022hands}
+Aur\'elien G\'eron.
+\newblock \emph{Hands-On Machine Learning with Scikit-Learn, Keras, and TensorFlow}.
+\newblock O'Reilly Media, 3rd edition, 2022.
+\end{thebibliography}
+
+\end{document}


### PR DESCRIPTION
## Summary
- expand the Week 1 intro notebook with richer textbook-referenced explanations, new transitions into the demos, and clearer training comments and homework prompts
- streamline the further reading list to two core deep-learning textbooks and align earlier citations to match
- add a LaTeX lab guide outlining objectives, workflow, and assignments for the lab session

## Testing
- `pdflatex W01_lab_guide.tex`


------
https://chatgpt.com/codex/tasks/task_e_68cd5dac088483268058e39c18babc91