### PR TITLE
Add timing metrics and summary table to Week 02 lab

### DIFF
--- a/notebooks/W02_perceptron_mlp.ipynb
+++ b/notebooks/W02_perceptron_mlp.ipynb
@@ -79,6 +79,7 @@
     "from tensorflow.keras import layers\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
+    "import time\n",
     "\n",
     "print(tf.__version__)\n",
     "\n",
@@ -172,9 +173,12 @@
     "]\n",
     "\n",
     "histories = {}\n",
+    "training_summaries = []\n",
+    "\n",
     "for model_key, hidden_layers, description in architectures:\n",
     "    print(f\"Training model: {model_key} ({description})\")\n",
     "    model = build_mlp(hidden_layers)\n",
+    "    start_time = time.perf_counter()\n",
     "    history = model.fit(\n",
     "        train_x,\n",
     "        train_y,\n",
@@ -183,9 +187,28 @@
     "        batch_size=128,\n",
     "        verbose=0\n",
     "    )\n",
+    "    elapsed = time.perf_counter() - start_time\n",
     "    histories[model_key] = history.history\n",
     "    val_acc = history.history[\"val_accuracy\"][-1]\n",
-    "    print(f\"Final validation accuracy: {val_acc:.3f}\")\n",
+    "    training_summaries.append({\n",
+    "        \"model\": model_key,\n",
+    "        \"description\": description,\n",
+    "        \"val_accuracy\": val_acc,\n",
+    "        \"train_time_sec\": elapsed,\n",
+    "    })\n",
+    "    print(f\"Final validation accuracy: {val_acc:.3f} (time: {elapsed:.2f}s)\")\n",
+    "\n",
+    "if training_summaries:\n",
+    "    print(\"\n",
+    "Architecture comparison summary:\")\n",
+    "    header = f\"{'Model':<20}{'Description':<30}{'Val Accuracy':<15}{'Train Time (s)':<15}\"\n",
+    "    print(header)\n",
+    "    print('-' * len(header))\n",
+    "    for summary in training_summaries:\n",
+    "        print(\n",
+    "            f\"{summary['model']:<20}{summary['description']:<30}\"\n",
+    "            f\"{summary['val_accuracy']:<15.3f}{summary['train_time_sec']:<15.2f}\"\n",
+    "        )\n",
     "\n",
     "fig, axes = plt.subplots(1, 2, figsize=(14, 4))\n",
     "for model_key, history in histories.items():\n",
@@ -202,7 +225,7 @@
     "axes[1].set_ylabel(\"Accuracy\")\n",
     "axes[1].legend()\n",
     "plt.tight_layout()\n",
-    "plt.show()"
+    "plt.show()\n"
    ]
   },
   {
@@ -370,6 +393,23 @@
     "3. **Activation sweep**: Experiment with `swish` (`tf.nn.swish`) or `gelu`. You can pass a callable to the `activation` argument.\n",
     "4. **TensorBoard logging (optional)**: Wrap training with `keras.callbacks.TensorBoard(log_dir=\"runs/week02\")` to visualize losses and gradients. Record at least one screenshot of your TensorBoard scalars.\n",
     "5. **Reflection**: For each experiment, note (a) the architecture, (b) activation(s), and (c) final training/validation accuracy. Summarize which design choices worked best and why.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1ae70d26",
+   "metadata": {},
+   "source": [
+    "## Week 02 Summary Table\n",
+    "\n",
+    "| Section | Focus | Key Takeaways |\n",
+    "| --- | --- | --- |\n",
+    "| Learning Objectives | Goals for the lab | Understand perceptron limitations, experiment with MLP depth/width, and practice diagnosing model capacity issues. |\n",
+    "| Data Preparation | Fashion-MNIST setup | Normalize, flatten, and create train/validation splits to enable rapid architecture experiments. |\n",
+    "| Architecture Comparison | Narrow vs. balanced vs. wide MLPs | Observe how layer depth and width influence convergence speed, accuracy, and runtime. |\n",
+    "| Underfitting vs. Overfitting | Extreme architectures | Contrast tiny and deep-unregularized networks to see bias/variance trade-offs in metrics. |\n",
+    "| Activation Function Experiments | Nonlinearity sweep | Evaluate ReLU, tanh, sigmoid, and ELU to highlight their impact on training dynamics. |\n",
+    "| Guided Exercises | Practice extensions | Encourage further tuning, regularization, and logging to consolidate Week 02 concepts. |"
    ]
   }
  ],


### PR DESCRIPTION
## Summary
- record training durations for each architecture in the Week 02 comparison loop and print a timing table alongside validation accuracy
- add a Week 02 summary markdown table to recap key sections of the lab

## Testing
- not run (notebook changes only)

------
https://chatgpt.com/codex/tasks/task_e_68e0975602d083268838193c2f9ac221