### PR TITLE
Add activation function comparison plot to Week 02 lab

### DIFF
--- a/notebooks/W02_perceptron_mlp.ipynb
+++ b/notebooks/W02_perceptron_mlp.ipynb
@@ -412,6 +412,38 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3c1ac681",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "import tensorflow as tf\n",
+    "\n",
+    "z = np.linspace(-5, 5, 400)\n",
+    "activations = {\n",
+    "    \"ReLU\": tf.nn.relu(z),\n",
+    "    \"ELU\": tf.nn.elu(z),\n",
+    "    \"Tanh\": tf.nn.tanh(z),\n",
+    "    \"Sigmoid\": tf.nn.sigmoid(z),\n",
+    "}\n",
+    "\n",
+    "plt.figure(figsize=(8, 5))\n",
+    "for name, values in activations.items():\n",
+    "    plt.plot(z, values, label=name)\n",
+    "plt.title(\"Activation Functions Covered So Far\")\n",
+    "plt.xlabel(\"Input (z)\")\n",
+    "plt.ylabel(\"Activation(z)\")\n",
+    "plt.axhline(0, color='black', linewidth=0.5)\n",
+    "plt.axvline(0, color='black', linewidth=0.5)\n",
+    "plt.legend()\n",
+    "plt.grid(True, linestyle='--', alpha=0.5)\n",
+    "plt.show()"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "6a62fe1c",
    "metadata": {},


### PR DESCRIPTION
## Summary
- add a new code cell before the activation function reference table in the Week 02 lab notebook
- plot ReLU, ELU, tanh, and sigmoid across a shared input range with clear labels and styling for quick visual comparison

## Testing
- not run (notebook change only)


------
https://chatgpt.com/codex/tasks/task_e_68e0a646ec208326b547953b26f1e125